### PR TITLE
fix(image): fix image disappearing after generation

### DIFF
--- a/src/components/ImageItem/index.tsx
+++ b/src/components/ImageItem/index.tsx
@@ -4,6 +4,7 @@ import { Trash } from 'lucide-react';
 import { CSSProperties, memo } from 'react';
 
 import { usePlatform } from '@/hooks/usePlatform';
+import { useChatStore } from '@/store/chat';
 
 import { MIN_IMAGE_SIZE } from './style';
 
@@ -33,11 +34,12 @@ const useStyles = createStyles(({ css, token }) => ({
   `,
 }));
 
-interface ImageItemProps {
+export interface ImageItemProps {
   alt?: string;
   alwaysShowClose?: boolean;
   className?: string;
   editable?: boolean;
+  imageId?: string;
   loading?: boolean;
   onClick?: () => void;
   onRemove?: () => void;
@@ -47,10 +49,23 @@ interface ImageItemProps {
 }
 
 const ImageItem = memo<ImageItemProps>(
-  ({ className, style, editable, alt, onRemove, url, loading, alwaysShowClose, preview }) => {
+  ({
+    className,
+    style,
+    editable,
+    alt,
+    onRemove,
+    url,
+    loading,
+    alwaysShowClose,
+    preview,
+    imageId,
+  }) => {
     const IMAGE_SIZE = editable ? MIN_IMAGE_SIZE : '100%';
     const { styles, cx } = useStyles();
     const { isSafari } = usePlatform();
+    const useFetchDalleImageItem = useChatStore((s) => s.useFetchDalleImageItem);
+    const { data } = useFetchDalleImageItem(imageId!);
 
     return (
       <Image
@@ -75,7 +90,7 @@ const ImageItem = memo<ImageItemProps>(
         isLoading={loading}
         preview={preview}
         size={IMAGE_SIZE as any}
-        src={url}
+        src={data || url}
         style={{ height: isSafari ? 'auto' : '100%', width: '100%', ...style }}
         wrapperClassName={cx(styles.image, editable && styles.editableImage)}
       />

--- a/src/store/chat/slices/builtinTool/actions/dalle.ts
+++ b/src/store/chat/slices/builtinTool/actions/dalle.ts
@@ -106,19 +106,5 @@ export const dalleSlice: StateCreator<
   },
 
   useFetchDalleImageItem: (id) =>
-    useClientDataSWR([SWR_FETCH_KEY, id], async () => {
-      const item = await fileService.getFile(id);
-
-      set(
-        produce((draft) => {
-          if (draft.dalleImageMap[id]) return;
-
-          draft.dalleImageMap[id] = item;
-        }),
-        false,
-        n('useFetchFile'),
-      );
-
-      return item;
-    }),
+    useClientDataSWR<string>([SWR_FETCH_KEY, id], () => fileService.getFile(id).then((i) => i.url)),
 });

--- a/src/store/chat/slices/builtinTool/initialState.ts
+++ b/src/store/chat/slices/builtinTool/initialState.ts
@@ -3,14 +3,12 @@ import { FileItem } from '@/types/files';
 export interface ChatToolState {
   activePageContentUrl?: string;
   dalleImageLoading: Record<string, boolean>;
-  dalleImageMap: Record<string, FileItem>;
   localFileLoading: Record<string, boolean>;
   searchLoading: Record<string, boolean>;
 }
 
 export const initialToolState: ChatToolState = {
   dalleImageLoading: {},
-  dalleImageMap: {},
   localFileLoading: {},
   searchLoading: {},
 };


### PR DESCRIPTION
This commit fixes a bug where images generated by AI models would disappear immediately after being displayed in the chat.

The bug was caused by the `previewUrl` being cleared after the image was uploaded to the server. The `ImageItem` component was not correctly re-rendering with the new `imageId`.

This commit fixes the bug by:

*   Modifying the `useFetchDalleImageItem` hook to return the image URL directly.
*   Updating the `ImageItem` component to use the new `useFetchDalleImageItem` hook to fetch the image URL.
*   Removing the `dalleImageMap` from the store, as it is no longer needed.

Note: The test suite is currently failing due to unrelated type-checking errors. These errors should be addressed in a separate commit.

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
